### PR TITLE
fix: use RESOURCE_GROUP secret in az group exists checks

### DIFF
--- a/.github/workflows/deploy-waf.yml
+++ b/.github/workflows/deploy-waf.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP }}
+      RESOURCE_GROUP: ${{ secrets.RESOURCE_GROUP }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -76,10 +76,10 @@ jobs:
         run: |
           set -e
           echo "Checking if resource group exists..."
-          rg_exists=$(az group exists --resource-group ${{ env.RESOURCE_GROUP_NAME }})
+          rg_exists=$(az group exists --resource-group ${{ env.RESOURCE_GROUP }})
           if [ "$rg_exists" = "false" ]; then
             echo "Resource group does not exist. Creating..."
-            az group create --name ${{ env.RESOURCE_GROUP_NAME }} --location ${{ env.AZURE_LOCATION }} || { echo "Error creating resource group"; exit 1; }
+            az group create --name ${{ env.RESOURCE_GROUP }} --location ${{ env.AZURE_LOCATION }} || { echo "Error creating resource group"; exit 1; }
           else
             echo "Resource group already exists."
           fi
@@ -98,7 +98,7 @@ jobs:
         run: |
           set -e
           az deployment group create \
-            --resource-group ${{ env.RESOURCE_GROUP_NAME }} \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
             --template-file infra/main.bicep \
             --parameters \
               environmentName=${{ env.SOLUTION_PREFIX }} \
@@ -133,13 +133,13 @@ jobs:
 
 
           set -e
-          echo "Fetching OpenAI resource from resource group ${{ env.RESOURCE_GROUP_NAME }}..."
+          echo "Fetching OpenAI resource from resource group ${{ env.RESOURCE_GROUP }}..."
 
           # Run the az resource list command to get the OpenAI resource name
-          openai_resource_name=$(az resource list --resource-group ${{ env.RESOURCE_GROUP_NAME }} --resource-type "Microsoft.CognitiveServices/accounts" --query "[0].name" -o tsv)
+          openai_resource_name=$(az resource list --resource-group ${{ env.RESOURCE_GROUP }} --resource-type "Microsoft.CognitiveServices/accounts" --query "[0].name" -o tsv)
 
           if [ -z "$openai_resource_name" ]; then
-            echo "No OpenAI resource found in resource group ${{ env.RESOURCE_GROUP_NAME }}."
+            echo "No OpenAI resource found in resource group ${{ env.RESOURCE_GROUP }}."
             exit 1
           else
             echo "OPENAI_RESOURCE_NAME=${openai_resource_name}" >> $GITHUB_ENV
@@ -151,14 +151,14 @@ jobs:
         run: |
           set -e  
           echo "Checking if resource group exists..."
-          rg_exists=$(az group exists --resource-group ${{ env.RESOURCE_GROUP_NAME }})
+          rg_exists=$(az group exists --resource-group ${{ env.RESOURCE_GROUP }})
           if [ "$rg_exists" = "true" ]; then
             echo "Resource group exist. Cleaning..."
             az group delete \
-                --name ${{ env.RESOURCE_GROUP_NAME }} \
+                --name ${{ env.RESOURCE_GROUP }} \
                 --yes \
                 --no-wait
-            echo "Resource group deleted...  ${{ env.RESOURCE_GROUP_NAME }}"
+            echo "Resource group deleted...  ${{ env.RESOURCE_GROUP }}"
           else
             echo "Resource group does not exists."
           fi
@@ -184,7 +184,7 @@ jobs:
             resource_found=false
 
             # Get the list of resources in YAML format again on each retry
-            resource_list=$(az resource list --resource-group ${{ env.RESOURCE_GROUP_NAME }} --output yaml)
+            resource_list=$(az resource list --resource-group ${{ env.RESOURCE_GROUP }} --output yaml)
 
             # Iterate through the resources to check
             for resource in "${resources_to_check[@]}"; do
@@ -223,7 +223,7 @@ jobs:
 
           # Purge OpenAI Resource
           echo "Purging the OpenAI Resource..."
-          if ! az resource delete --ids /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}/providers/Microsoft.CognitiveServices/locations/eastus/resourceGroups/${{ env.RESOURCE_GROUP_NAME }}/deletedAccounts/${{ env.OPENAI_RESOURCE_NAME }} --verbose; then
+          if ! az resource delete --ids /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}/providers/Microsoft.CognitiveServices/locations/eastus/resourceGroups/${{ env.RESOURCE_GROUP }}/deletedAccounts/${{ env.OPENAI_RESOURCE_NAME }} --verbose; then
             echo "Failed to purge openai resource: ${{ env.OPENAI_RESOURCE_NAME }}"
           else
             echo "Purged the openai resource: ${{ env.OPENAI_RESOURCE_NAME }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP }}
+      RESOURCE_GROUP: ${{ secrets.RESOURCE_GROUP }}
     outputs:
-      RESOURCE_GROUP_NAME: ${{ steps.check_create_rg.outputs.RESOURCE_GROUP_NAME }}
+      RESOURCE_GROUP: ${{ steps.check_create_rg.outputs.RESOURCE_GROUP }}
       WEBAPP_URL: ${{ steps.get_output.outputs.WEBAPP_URL }}
       DEPLOYMENT_SUCCESS: ${{ steps.deployment_status.outputs.SUCCESS }}
       MACAE_URL_API: ${{ steps.get_backend_url.outputs.MACAE_URL_API }}
@@ -90,11 +90,11 @@ jobs:
         id: check_create_rg
         run: |
           set -e
-          rg_exists=$(az group exists --resource-group ${{ env.RESOURCE_GROUP_NAME }})
+          rg_exists=$(az group exists --resource-group ${{ env.RESOURCE_GROUP }})
           if [ "$rg_exists" = "false" ]; then
-            az group create --name ${{ env.RESOURCE_GROUP_NAME }} --location ${{ env.AZURE_LOCATION }}
+            az group create --name ${{ env.RESOURCE_GROUP }} --location ${{ env.AZURE_LOCATION }}
           fi
-          echo "RESOURCE_GROUP_NAME=${{ env.RESOURCE_GROUP_NAME }}" >> $GITHUB_OUTPUT
+          echo "RESOURCE_GROUP=${{ env.RESOURCE_GROUP }}" >> $GITHUB_OUTPUT
 
       - name: Generate Unique Solution Prefix
         id: generate_solution_prefix
@@ -119,7 +119,7 @@ jobs:
           fi
 
           az deployment group create \
-            --resource-group ${{ env.RESOURCE_GROUP_NAME }} \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
             --template-file infra/main.bicep \
             --parameters \
               environmentName=${{ env.SOLUTION_PREFIX }} \
@@ -140,7 +140,7 @@ jobs:
       - name: Extract Web App and API App URLs
         id: get_output
         run: |
-          WEBAPP_NAMES=$(az webapp list --resource-group ${{ env.RESOURCE_GROUP_NAME }} --query "[].name" -o tsv)
+          WEBAPP_NAMES=$(az webapp list --resource-group ${{ env.RESOURCE_GROUP }} --query "[].name" -o tsv)
           for NAME in $WEBAPP_NAMES; do
             if [[ $NAME == app-* ]]; then
               WEBAPP_URL="https://${NAME}.azurewebsites.net"
@@ -152,12 +152,12 @@ jobs:
         id: get_backend_url
         run: |
           CONTAINER_APP_NAME=$(az containerapp list \
-            --resource-group ${{ env.RESOURCE_GROUP_NAME }} \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
             --query "[0].name" -o tsv)
 
           MACAE_URL_API=$(az containerapp show \
             --name "$CONTAINER_APP_NAME" \
-            --resource-group ${{ env.RESOURCE_GROUP_NAME }} \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
             --query "properties.configuration.ingress.fqdn" -o tsv)
 
           echo "MACAE_URL_API=https://${MACAE_URL_API}" >> $GITHUB_OUTPUT
@@ -180,16 +180,16 @@ jobs:
     with:
       MACAE_WEB_URL: ${{ needs.deploy.outputs.WEBAPP_URL }}
       MACAE_URL_API: ${{ needs.deploy.outputs.MACAE_URL_API }}
-      MACAE_RG: ${{ needs.deploy.outputs.RESOURCE_GROUP_NAME }}
+      MACAE_RG: ${{ needs.deploy.outputs.RESOURCE_GROUP }}
       MACAE_CONTAINER_APP: ${{ needs.deploy.outputs.CONTAINER_APP }}
     secrets: inherit
 
   cleanup-deployment:
-    if: always() && needs.deploy.outputs.RESOURCE_GROUP_NAME != ''
+    if: always() && needs.deploy.outputs.RESOURCE_GROUP != ''
     needs: [deploy, e2e-test]
     runs-on: ubuntu-latest
     env:
-      RESOURCE_GROUP_NAME: ${{ needs.deploy.outputs.RESOURCE_GROUP_NAME }}
+      RESOURCE_GROUP: ${{ needs.deploy.outputs.RESOURCE_GROUP }}
     steps:
       - name: Setup Azure CLI
         run: |
@@ -206,12 +206,12 @@ jobs:
           echo "Fetching AI Services and Key Vault names before deletion..."
 
           # Get Key Vault name
-          KEYVAULT_NAME=$(az resource list --resource-group "${{ env.RESOURCE_GROUP_NAME }}" --resource-type "Microsoft.KeyVault/vaults" --query "[].name" -o tsv)
+          KEYVAULT_NAME=$(az resource list --resource-group "${{ env.RESOURCE_GROUP }}" --resource-type "Microsoft.KeyVault/vaults" --query "[].name" -o tsv)
           echo "Detected Key Vault: $KEYVAULT_NAME"
           echo "KEYVAULT_NAME=$KEYVAULT_NAME" >> $GITHUB_ENV
           # Extract AI Services names
           echo "Fetching AI Services..."
-          AI_SERVICES=$(az resource list --resource-group '${{ env.RESOURCE_GROUP_NAME }}' --resource-type "Microsoft.CognitiveServices/accounts" --query "[].name" -o tsv)
+          AI_SERVICES=$(az resource list --resource-group '${{ env.RESOURCE_GROUP }}' --resource-type "Microsoft.CognitiveServices/accounts" --query "[].name" -o tsv)
           # Flatten newline-separated values to space-separated
           AI_SERVICES=$(echo "$AI_SERVICES" | paste -sd ' ' -)
           echo "Detected AI Services: $AI_SERVICES"
@@ -222,13 +222,13 @@ jobs:
         run: |
 
           set -e
-          echo "Fetching OpenAI resource from resource group ${{ env.RESOURCE_GROUP_NAME }}..."
+          echo "Fetching OpenAI resource from resource group ${{ env.RESOURCE_GROUP }}..."
 
           # Run the az resource list command to get the OpenAI resource name
-          openai_resource_name=$(az resource list --resource-group ${{ env.RESOURCE_GROUP_NAME }} --resource-type "Microsoft.CognitiveServices/accounts" --query "[0].name" -o tsv)
+          openai_resource_name=$(az resource list --resource-group ${{ env.RESOURCE_GROUP }} --resource-type "Microsoft.CognitiveServices/accounts" --query "[0].name" -o tsv)
 
           if [ -z "$openai_resource_name" ]; then
-            echo "No OpenAI resource found in resource group ${{ env.RESOURCE_GROUP_NAME }}."
+            echo "No OpenAI resource found in resource group ${{ env.RESOURCE_GROUP }}."
             exit 0
           else
             echo "OPENAI_RESOURCE_NAME=${openai_resource_name}" >> $GITHUB_ENV
@@ -240,14 +240,14 @@ jobs:
         run: |
           set -e
           echo "Checking if resource group exists..."
-          rg_exists=$(az group exists --resource-group ${{ env.RESOURCE_GROUP_NAME }})
+          rg_exists=$(az group exists --resource-group ${{ env.RESOURCE_GROUP }})
           if [ "$rg_exists" = "true" ]; then
             echo "Resource group exist. Cleaning..."
             az group delete \
-                --name ${{ env.RESOURCE_GROUP_NAME }} \
+                --name ${{ env.RESOURCE_GROUP }} \
                 --yes \
                 --no-wait
-            echo "Resource group deleted...  ${{ env.RESOURCE_GROUP_NAME }}"
+            echo "Resource group deleted...  ${{ env.RESOURCE_GROUP }}"
           else
             echo "Resource group does not exists."
           fi
@@ -272,7 +272,7 @@ jobs:
             resource_found=false
 
             # Get the list of resources in YAML format again on each retry
-            resource_list=$(az resource list --resource-group ${{ env.RESOURCE_GROUP_NAME }} --output yaml)
+            resource_list=$(az resource list --resource-group ${{ env.RESOURCE_GROUP }} --output yaml)
 
             # Iterate through the resources to check
             for resource in "${resources_to_check[@]}"; do
@@ -311,7 +311,7 @@ jobs:
 
           # Purge OpenAI Resource
           echo "Purging the OpenAI Resource..."
-          if ! az resource delete --ids /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}/providers/Microsoft.CognitiveServices/locations/eastus/resourceGroups/${{ env.RESOURCE_GROUP_NAME }}/deletedAccounts/${{ env.OPENAI_RESOURCE_NAME }} --verbose; then
+          if ! az resource delete --ids /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}/providers/Microsoft.CognitiveServices/locations/eastus/resourceGroups/${{ env.RESOURCE_GROUP }}/deletedAccounts/${{ env.OPENAI_RESOURCE_NAME }} --verbose; then
             echo "Failed to purge openai resource: ${{ env.OPENAI_RESOURCE_NAME }}"
           else
             echo "Purged the openai resource: ${{ env.OPENAI_RESOURCE_NAME }}"


### PR DESCRIPTION
## Summary
- use RESOURCE_GROUP secret in deploy workflows when checking resource groups
- standardize env var RESOURCE_GROUP for subsequent scripts

## Testing
- `pytest` *(fails: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_689509bc4f308331ba2d7989a186e4db